### PR TITLE
Struct func handler doesn't work

### DIFF
--- a/fn/handler.go
+++ b/fn/handler.go
@@ -88,6 +88,8 @@ func fromFunc(fn_ interface{}, rcvr_ interface{}) rpc.Handler {
 			switch fntyp.In(idx).Kind() {
 			case reflect.Int:
 				fnParams = append(fnParams, reflect.ValueOf(int(param.(float64))))
+			case reflect.Ptr, reflect.Struct:
+				r.Return(errors.New("fn: cannot cast map[string]interface{} to struct"))
 			default:
 				fnParams = append(fnParams, reflect.ValueOf(param))
 			}

--- a/fn/handler.go
+++ b/fn/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/progrium/qtalk-go/rpc"
 )
@@ -63,6 +64,10 @@ func fromFunc(fn_ interface{}, rcvr_ interface{}) rpc.Handler {
 		params := reflect.New(reflect.TypeOf([]interface{}{}))
 
 		if err := c.Receive(params.Interface()); err != nil {
+			if strings.HasPrefix(err.Error(), "json: cannot unmarshal object into Go value of type") {
+				r.Return(errors.New("fn: wrap with fn.Args{}"))
+				return
+			}
 			r.Return(fmt.Errorf("fn: args: %s", err.Error()))
 			return
 		}

--- a/fn/handler_test.go
+++ b/fn/handler_test.go
@@ -118,9 +118,7 @@ func TestHandlerFromFunc(t *testing.T) {
 	})
 
 	t.Run("no return", func(t *testing.T) {
-		client, _ := rpctest.NewPair(HandlerFrom(func(a, b int) {
-			return
-		}), codec.JSONCodec{})
+		client, _ := rpctest.NewPair(HandlerFrom(func(a, b int) {}), codec.JSONCodec{})
 		defer client.Close()
 
 		var sum int

--- a/fn/handler_test.go
+++ b/fn/handler_test.go
@@ -178,9 +178,16 @@ func TestHandlerFromMethods(t *testing.T) {
 	}
 
 	var reply mockStruct
-	if _, err := client.Call(ctx, "Struct", &mockStruct{S: "a"}, &reply); err != nil {
-		t.Error(err)
+	_, err := client.Call(ctx, "Struct", &mockStruct{S: "a"}, &reply)
+	if !strings.HasSuffix(err.Error(), "fn: wrap with fn.Args{}") {
+		t.Errorf("unexpected err: %+v", err)
 	}
+
+	_, err = client.Call(ctx, "Struct", Args{&mockStruct{S: "a"}}, &reply)
+	if !strings.HasSuffix(err.Error(), "fn: wrap with fn.Args{}") {
+		t.Errorf("unexpected err: %+v", err)
+	}
+
 	if reply.S != "A" {
 		t.Errorf("unexpected ret: %+v", reply)
 	}

--- a/fn/ptr.go
+++ b/fn/ptr.go
@@ -162,7 +162,7 @@ func keys(v reflect.Value) []string {
 			}
 			keys = append(keys, k)
 		}
-		sort.Sort(sort.StringSlice(keys))
+		sort.Strings(keys)
 		return keys
 	case reflect.Struct:
 		t := v.Type()


### PR DESCRIPTION
I can dig in, it'll be a good chance to dust off my Go reflection skills.

```sh
$ go test ./fn
--- FAIL: TestHandlerFromMethods (0.00s)
    handler_test.go:184: remote: fn: args: json: cannot unmarshal object into Go value of type []interface {}
    handler_test.go:187: unexpected ret: {S:}
FAIL
FAIL	github.com/progrium/qtalk-go/fn	0.398s
FAIL
```