### PR TITLE
HandlerFrom: restrict to interface methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.18.x]
+        go-version: [1.18.x, 1.19.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/fn/handler.go
+++ b/fn/handler.go
@@ -53,6 +53,9 @@ func HandlerFrom[T any](v T) rpc.Handler {
 type Args []any
 
 func fromMethods(rcvr interface{}, t reflect.Type) rpc.Handler {
+	// If `t` is an interface, `Convert()` wraps the value with that interface
+	// type. This makes sure that the Method(i) indexes match for getting both the
+	// name and implementation.
 	rcvrval := reflect.ValueOf(rcvr).Convert(t)
 	mux := rpc.NewRespondMux()
 	for i := 0; i < t.NumMethod(); i++ {

--- a/fn/handler.go
+++ b/fn/handler.go
@@ -16,6 +16,13 @@ import (
 // registering each method as a handler using its method name. From there, methods
 // are treated just like functions.
 //
+// The registered methods can be limited by providing an interface type parameter:
+//
+//	h := HandlerFrom[interface{
+//		OnlyTheseMethods()
+//		WillBeRegistered()
+//	}](myHandlerImplementation)
+//
 // Function handlers expect an array to use as arguments. If the incoming argument
 // array is too large or too small, the handler returns an error. Functions can opt-in
 // to take a final Call pointer argument, allowing the handler to give it the Call value

--- a/fn/handler.go
+++ b/fn/handler.go
@@ -42,7 +42,7 @@ func HandlerFrom(v interface{}) rpc.Handler {
 // Args is the expected argument value for calls made to HandlerFrom handlers.
 // Since it is just a slice of empty interface values, you can alternatively use
 // more specific slice types ([]int{}, etc) if all arguments are of the same type.
-type Args []interface{}
+type Args []any
 
 func fromMethods(rcvr interface{}) rpc.Handler {
 	t := reflect.TypeOf(rcvr)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/progrium/qtalk-go
 
-go 1.16
+go 1.18
 
 require (
 	github.com/mitchellh/mapstructure v1.4.3


### PR DESCRIPTION
Adds a type parameter to `HandlerFrom` that can be used to to restrict the
handler to the methods on an interface.

This is a variation on the solution for #21 to use generics to indicate the type
to use here. It abstracts some of the concerns about passing an interface
*pointer* like `(*interface{})(nil)` as well as having static type checking that
the value actually implements the provided interface.

In the typical case the type parameter can be inferred to just be the type of
the value, so existing calls should still work without changing the signature.

IIRC the `any` type already used in the code was added in Go 1.18 as part of the
generics changes, so this would already require that version.

If you prefer not to use generics, the rest of the code should work with a few
minor changes.

Resolves #21 
