### PR TITLE
bump Go requirement to 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.18.x]
+        go-version: [1.18.x, 1.19.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/fn/handler.go
+++ b/fn/handler.go
@@ -42,7 +42,7 @@ func HandlerFrom(v interface{}) rpc.Handler {
 // Args is the expected argument value for calls made to HandlerFrom handlers.
 // Since it is just a slice of empty interface values, you can alternatively use
 // more specific slice types ([]int{}, etc) if all arguments are of the same type.
-type Args []interface{}
+type Args []any
 
 func fromMethods(rcvr interface{}) rpc.Handler {
 	t := reflect.TypeOf(rcvr)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/progrium/qtalk-go
 
-go 1.16
+go 1.18
 
 require (
 	github.com/mitchellh/mapstructure v1.4.3


### PR DESCRIPTION
Removes 1.16 from GitHub Actions, and adds 1.19.

Changed `handler.Args` to `[]any` as a simple verification of building
with 1.18.
