### PR TITLE
fn: extract Call helpers from HandlerFrom

### DIFF
--- a/fn/call.go
+++ b/fn/call.go
@@ -1,0 +1,86 @@
+package fn
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+var errorInterface = reflect.TypeOf((*error)(nil)).Elem()
+
+// Call wraps invoking a function via reflection, converting the arguments with
+// ArgsTo and the returns with ParseReturn.
+func Call(fn any, args []any) ([]any, error) {
+	fnval := reflect.ValueOf(fn)
+	fnParams, err := ArgsTo(fnval.Type(), args)
+	if err != nil {
+		return nil, err
+	}
+	fnReturn := fnval.Call(fnParams)
+	return ParseReturn(fnReturn)
+}
+
+// ArgsTo converts the arguments into `reflect.Value`s suitable to pass as
+// parameters to a function with the given type via reflection.
+func ArgsTo(fntyp reflect.Type, args []any) ([]reflect.Value, error) {
+	if len(args) != fntyp.NumIn() {
+		return nil, fmt.Errorf("fn: expected %d params, got %d", fntyp.NumIn(), len(args))
+	}
+	fnParams := make([]reflect.Value, len(args))
+	for idx, param := range args {
+		switch fntyp.In(idx).Kind() {
+		case reflect.Struct:
+			// decode to struct type using mapstructure
+			arg := reflect.New(fntyp.In(idx))
+			if err := mapstructure.Decode(param, arg.Interface()); err != nil {
+				return nil, fmt.Errorf("fn: mapstructure: %s", err.Error())
+			}
+			fnParams[idx] = ensureType(arg.Elem(), fntyp.In(idx))
+		case reflect.Slice:
+			rv := reflect.ValueOf(param)
+			// decode slice of structs to struct type using mapstructure
+			if fntyp.In(idx).Elem().Kind() == reflect.Struct {
+				nv := reflect.MakeSlice(fntyp.In(idx), rv.Len(), rv.Len())
+				for i := 0; i < rv.Len(); i++ {
+					ref := reflect.New(nv.Index(i).Type())
+					if err := mapstructure.Decode(rv.Index(i).Interface(), ref.Interface()); err != nil {
+						return nil, fmt.Errorf("fn: mapstructure: %s", err.Error())
+					}
+					nv.Index(i).Set(reflect.Indirect(ref))
+				}
+				rv = nv
+			}
+			fnParams[idx] = rv
+		case reflect.Int:
+			// if int is expected cast the float64 (assumes json-like encoding)
+			fnParams[idx] = ensureType(reflect.ValueOf(int(param.(float64))), fntyp.In(idx))
+		default:
+			fnParams[idx] = ensureType(reflect.ValueOf(param), fntyp.In(idx))
+		}
+	}
+	return fnParams, nil
+}
+
+// ParseReturn splits the results of reflect.Call() into the values, and
+// possibly an error.
+// If the last value is a non-nil error, this will return `nil, err`.
+// If the last value is a nil error it will be removed from the value list.
+// Any remaining values will be converted and returned as `any` typed values.
+func ParseReturn(ret []reflect.Value) ([]any, error) {
+	if len(ret) == 0 {
+		return nil, nil
+	}
+	last := ret[len(ret)-1]
+	if last.Type().Implements(errorInterface) {
+		if !last.IsNil() {
+			return nil, last.Interface().(error)
+		}
+		ret = ret[:len(ret)-1]
+	}
+	out := make([]any, len(ret))
+	for i, r := range ret {
+		out[i] = r.Interface()
+	}
+	return out, nil
+}

--- a/fn/call.go
+++ b/fn/call.go
@@ -11,7 +11,12 @@ var errorInterface = reflect.TypeOf((*error)(nil)).Elem()
 
 // Call wraps invoking a function via reflection, converting the arguments with
 // ArgsTo and the returns with ParseReturn.
-func Call(fn any, args []any) ([]any, error) {
+func Call(fn any, args []any) (_ []any, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("panic: %s [%s]", p, identifyPanic())
+		}
+	}()
 	fnval := reflect.ValueOf(fn)
 	fnParams, err := ArgsTo(fnval.Type(), args)
 	if err != nil {

--- a/fn/call_test.go
+++ b/fn/call_test.go
@@ -3,6 +3,7 @@ package fn
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -31,6 +32,16 @@ func equal(expected, actual []any) bool {
 		return len(actual) == 0
 	}
 	return reflect.DeepEqual(expected, actual)
+}
+
+func TestCallCatchPanic(t *testing.T) {
+	ret, err := Call(func() { panic("catch me!") }, nil)
+	if ret != nil {
+		t.Errorf("expected nil return, got: %v", ret)
+	}
+	if err == nil || !strings.Contains(err.Error(), "catch me!") {
+		t.Errorf("expected to panic info in an error, got: %v", err)
+	}
 }
 
 func TestParseReturn(t *testing.T) {

--- a/fn/call_test.go
+++ b/fn/call_test.go
@@ -73,6 +73,11 @@ func TestParseReturn(t *testing.T) {
 			"multiple value with non-nil error", func() (int, float64, error) { return 42, 0.5, fmt.Errorf("an error") }, nil,
 			nil, true,
 		},
+
+		{
+			"return error as value", func() any { return fmt.Errorf("an error") }, nil,
+			[]any{fmt.Errorf("an error")}, false,
+		},
 	}
 	for _, td := range tests {
 		t.Run(td.name, func(t *testing.T) {

--- a/fn/call_test.go
+++ b/fn/call_test.go
@@ -44,6 +44,25 @@ func TestCallCatchPanic(t *testing.T) {
 	}
 }
 
+func TestCallArgStructSlice(t *testing.T) {
+	type arg struct{ V int }
+
+	acutal, err := Call(func(vs []arg) int {
+		sum := 0
+		for _, v := range vs {
+			sum += v.V
+		}
+		return sum
+	}, []any{[]arg{{1}, {2}, {3}}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []any{int(6)}
+	if !reflect.DeepEqual(expected, acutal) {
+		t.Errorf("expected %#v, got %#v", expected, acutal)
+	}
+}
+
 func TestParseReturn(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/fn/call_test.go
+++ b/fn/call_test.go
@@ -1,0 +1,90 @@
+package fn
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func fatal(err error, t *testing.T) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func callParseReturn(fn interface{}, args []reflect.Value) ([]any, error) {
+	ret := reflect.ValueOf(fn).Call(args)
+	return ParseReturn(ret)
+}
+
+func values(args ...any) []reflect.Value {
+	r := make([]reflect.Value, len(args))
+	for i, a := range args {
+		r[i] = reflect.ValueOf(a)
+	}
+	return r
+}
+
+func equal(expected, actual []any) bool {
+	if len(expected) == 0 {
+		return len(actual) == 0
+	}
+	return reflect.DeepEqual(expected, actual)
+}
+
+func TestParseReturn(t *testing.T) {
+	tests := []struct {
+		name        string
+		fn          interface{}
+		args        []reflect.Value
+		expected    []any
+		expectedErr bool
+	}{
+		{"no return values", func() {}, nil, nil, false},
+		{
+			"single value return", func(i int) int { return i * 2 }, values(int(21)),
+			[]any{int(42)}, false,
+		},
+		{
+			"multiple value return", func(i int) (int, float64) {
+				return i * 2, float64(i) / 2
+			}, values(int(21)),
+			[]any{int(42), float64(10.5)}, false,
+		},
+
+		{"return nil error", func() error { return nil }, nil, nil, false},
+		{"return non-nil error", func() error { return fmt.Errorf("an error") }, nil, nil, true},
+
+		{
+			"single value with nil error", func() (int, error) { return 42, nil }, nil,
+			[]any{int(42)}, false,
+		},
+		{
+			"single value with non-nil error", func() (int, error) { return 42, fmt.Errorf("an error") }, nil,
+			nil, true,
+		},
+
+		{
+			"multiple value with nil error", func() (int, float64, error) { return 42, 0.5, nil }, nil,
+			[]any{int(42), float64(0.5)}, false,
+		},
+		{
+			"multiple value with non-nil error", func() (int, float64, error) { return 42, 0.5, fmt.Errorf("an error") }, nil,
+			nil, true,
+		},
+	}
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			actual, err := callParseReturn(td.fn, td.args)
+			if !td.expectedErr {
+				fatal(err, t)
+			} else if err == nil {
+				t.Fatalf("expected an error")
+			}
+			if !equal(td.expected, actual) {
+				t.Errorf("expected: %v\ngot: %v", td.expected, actual)
+			}
+		})
+	}
+}

--- a/fn/handler_test.go
+++ b/fn/handler_test.go
@@ -98,7 +98,7 @@ func TestHandlerFromFunc(t *testing.T) {
 
 		var sum int
 		_, err := client.Call(context.Background(), "", []interface{}{2}, &sum)
-		if err == nil || !strings.Contains(err.Error(), "too few") {
+		if err == nil || !strings.Contains(err.Error(), "expected 2 params") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -111,7 +111,7 @@ func TestHandlerFromFunc(t *testing.T) {
 
 		var sum int
 		_, err := client.Call(context.Background(), "", []interface{}{2, 3, 5}, &sum)
-		if err == nil || !strings.Contains(err.Error(), "too many") {
+		if err == nil || !strings.Contains(err.Error(), "expected 2 params") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})


### PR DESCRIPTION
Pulls out some of the implementation of `HandlerFrom` for calling functions via
reflection into some more general purpose helper functions.

Fixes #23, #24
