### PR TITLE
turn Session and Channel into interfaces

### DIFF
--- a/mux/dial_io.go
+++ b/mux/dial_io.go
@@ -6,11 +6,11 @@ import (
 )
 
 // DialIO establishes a mux session using a WriterCloser and ReadCloser.
-func DialIO(out io.WriteCloser, in io.ReadCloser) (*Session, error) {
+func DialIO(out io.WriteCloser, in io.ReadCloser) (Session, error) {
 	return New(&ioduplex{out, in}), nil
 }
 
 // DialIO establishes a mux session using Stdout and Stdin.
-func DialStdio() (*Session, error) {
+func DialStdio() (Session, error) {
 	return DialIO(os.Stdout, os.Stdin)
 }

--- a/mux/dial_net.go
+++ b/mux/dial_net.go
@@ -4,7 +4,7 @@ import (
 	"net"
 )
 
-func dialNet(proto, addr string) (*Session, error) {
+func dialNet(proto, addr string) (Session, error) {
 	conn, err := net.Dial(proto, addr)
 	if err != nil {
 		return nil, err
@@ -13,11 +13,11 @@ func dialNet(proto, addr string) (*Session, error) {
 }
 
 // DialTCP establishes a mux session via TCP connection.
-func DialTCP(addr string) (*Session, error) {
+func DialTCP(addr string) (Session, error) {
 	return dialNet("tcp", addr)
 }
 
 // DialUnix establishes a mux session via Unix domain socket.
-func DialUnix(path string) (*Session, error) {
+func DialUnix(path string) (Session, error) {
 	return dialNet("unix", path)
 }

--- a/mux/dial_ws.go
+++ b/mux/dial_ws.go
@@ -9,7 +9,7 @@ import (
 // DialWS establishes a mux session via WebSocket connection.
 // The address must be a host and port. Opening a WebSocket
 // connection at a particular path is not supported.
-func DialWS(addr string) (*Session, error) {
+func DialWS(addr string) (Session, error) {
 	ws, err := websocket.Dial(fmt.Sprintf("ws://%s/", addr), "", fmt.Sprintf("http://%s/", addr))
 	if err != nil {
 		return nil, err

--- a/mux/listen.go
+++ b/mux/listen.go
@@ -9,7 +9,7 @@ type Listener interface {
 	Close() error
 
 	// Accept waits for and returns the next incoming session.
-	Accept() (*Session, error)
+	Accept() (Session, error)
 
 	// Addr returns the listener's network address if available.
 	Addr() net.Addr

--- a/mux/listen_io.go
+++ b/mux/listen_io.go
@@ -12,7 +12,7 @@ type ioListener struct {
 }
 
 // Accept will always return the wrapped ReadWriteCloser as a mux session.
-func (l *ioListener) Accept() (*Session, error) {
+func (l *ioListener) Accept() (Session, error) {
 	return New(l.ReadWriteCloser), nil
 }
 

--- a/mux/listen_net.go
+++ b/mux/listen_net.go
@@ -10,7 +10,7 @@ type netListener struct {
 }
 
 // Accept waits for and returns the next connected session to the listener.
-func (l *netListener) Accept() (*Session, error) {
+func (l *netListener) Accept() (Session, error) {
 	conn, err := l.Listener.Accept()
 	if err != nil {
 		return nil, err

--- a/mux/listen_ws.go
+++ b/mux/listen_ws.go
@@ -11,11 +11,11 @@ import (
 // wsListener wraps a net.Listener and WebSocket server to return connected mux sessions.
 type wsListener struct {
 	net.Listener
-	accepted chan *Session
+	accepted chan Session
 }
 
 // Accept waits for and returns the next connected session to the listener.
-func (l *wsListener) Accept() (*Session, error) {
+func (l *wsListener) Accept() (Session, error) {
 	sess, ok := <-l.accepted
 	if !ok {
 		return nil, io.EOF
@@ -42,7 +42,7 @@ func ListenWS(addr string) (Listener, error) {
 	}
 	wsl := &wsListener{
 		Listener: l,
-		accepted: make(chan *Session),
+		accepted: make(chan Session),
 	}
 	srv := &http.Server{
 		Addr: addr,

--- a/mux/proxy.go
+++ b/mux/proxy.go
@@ -10,7 +10,7 @@ import (
 // an io.Copy in both directions in goroutines. Proxy returns non-EOF errors
 // from src.Accept, nil on EOF, and any errors from dst.Open after closing
 // the accepted channel from src.
-func Proxy(dst *Session, src *Session) error {
+func Proxy(dst, src Session) error {
 	for {
 		ctx := context.Background()
 		a, err := src.Accept()
@@ -29,7 +29,7 @@ func Proxy(dst *Session, src *Session) error {
 	}
 }
 
-func proxy(a, b *Channel) {
+func proxy(a, b Channel) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {

--- a/mux/proxy_test.go
+++ b/mux/proxy_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func setupProxy(t *testing.T) (func(), chan error, *Session, *Session) {
+func setupProxy(t *testing.T) (func(), chan error, Session, Session) {
 	la, err := net.Listen("tcp", "127.0.0.1:0")
 	fatal(err, t)
 	lb, err := net.Listen("tcp", "127.0.0.1:0")

--- a/mux/session_test.go
+++ b/mux/session_test.go
@@ -61,7 +61,7 @@ func TestQmux(t *testing.T) {
 
 	sess := New(conn)
 
-	var ch *Channel
+	var ch Channel
 	t.Run("session accept", func(t *testing.T) {
 		ch, err = sess.Accept()
 		fatal(err, t)

--- a/mux/transport_test.go
+++ b/mux/transport_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 )
 
-func testExchange(t *testing.T, sess *Session) {
+func testExchange(t *testing.T, sess Session) {
 	var err error
-	var ch *Channel
+	var ch Channel
 	t.Run("session accept", func(t *testing.T) {
 		ch, err = sess.Accept()
 		fatal(err, t)

--- a/mux/util_chanlist.go
+++ b/mux/util_chanlist.go
@@ -9,11 +9,11 @@ type chanList struct {
 
 	// chans are indexed by the local id of the channel, which the
 	// other side should send in the PeersId field.
-	chans []*Channel
+	chans []*channel
 }
 
 // Assigns a channel ID to the given channel.
-func (c *chanList) add(ch *Channel) uint32 {
+func (c *chanList) add(ch *channel) uint32 {
 	c.Lock()
 	defer c.Unlock()
 	for i := range c.chans {
@@ -27,7 +27,7 @@ func (c *chanList) add(ch *Channel) uint32 {
 }
 
 // getChan returns the channel for the given ID.
-func (c *chanList) getChan(id uint32) *Channel {
+func (c *chanList) getChan(id uint32) *channel {
 	c.Lock()
 	defer c.Unlock()
 	if id < uint32(len(c.chans)) {
@@ -45,10 +45,10 @@ func (c *chanList) remove(id uint32) {
 }
 
 // dropAll forgets all channels it knows, returning them in a slice.
-func (c *chanList) dropAll() []*Channel {
+func (c *chanList) dropAll() []*channel {
 	c.Lock()
 	defer c.Unlock()
-	var r []*Channel
+	var r []*channel
 
 	for _, ch := range c.chans {
 		if ch == nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -18,12 +18,12 @@ func (e RemoteError) Error() string {
 
 // Client wraps a session and codec to make RPC calls over the session.
 type Client struct {
-	*mux.Session
+	mux.Session
 	codec codec.Codec
 }
 
 // NewClient takes a session and codec to make a client for making RPC calls.
-func NewClient(session *mux.Session, codec codec.Codec) *Client {
+func NewClient(session mux.Session, codec codec.Codec) *Client {
 	return &Client{
 		Session: session,
 		codec:   codec,

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -36,7 +36,7 @@ type Call struct {
 	Caller  Caller
 	Decoder codec.Decoder
 	Context context.Context
-	ch      *mux.Channel
+	ch      mux.Channel
 }
 
 // Receive will decode an incoming value from the underlying channel. It can be
@@ -63,7 +63,7 @@ type ResponseHeader struct {
 type Response struct {
 	ResponseHeader
 	Reply   interface{}
-	Channel *mux.Channel
+	Channel mux.Channel
 
 	codec codec.Codec
 }
@@ -86,7 +86,7 @@ type Responder interface {
 	// Continue sets the response to keep the channel open after sending a return value,
 	// and returns the underlying channel for you to take control of. If called, you
 	// become responsible for closing the channel.
-	Continue(interface{}) (*mux.Channel, error)
+	Continue(interface{}) (mux.Channel, error)
 
 	// Send encodes a value over the underlying channel, but does not initiate a response,
 	// so it must be used after calling Continue.
@@ -96,7 +96,7 @@ type Responder interface {
 type responder struct {
 	responded bool
 	header    *ResponseHeader
-	ch        *mux.Channel
+	ch        mux.Channel
 	c         codec.Codec
 }
 
@@ -108,7 +108,7 @@ func (r *responder) Return(v interface{}) error {
 	return r.respond(v, false)
 }
 
-func (r *responder) Continue(v interface{}) (*mux.Channel, error) {
+func (r *responder) Continue(v interface{}) (mux.Channel, error) {
 	return r.ch, r.respond(v, true)
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -37,7 +37,7 @@ func (s *Server) Serve(l net.Listener) error {
 // returned. If the handler does not call Continue, the channel will be closed. Respond will panic if Codec is nil.
 //
 // If the context is not nil, it will be added to Calls. Otherwise the Call Context will be set to a context.Background().
-func (s *Server) Respond(sess *mux.Session, ctx context.Context) {
+func (s *Server) Respond(sess mux.Session, ctx context.Context) {
 	defer sess.Close()
 
 	if s.Codec == nil {
@@ -61,7 +61,7 @@ func (s *Server) Respond(sess *mux.Session, ctx context.Context) {
 	}
 }
 
-func (s *Server) respond(hn Handler, sess *mux.Session, ch *mux.Channel, ctx context.Context) {
+func (s *Server) respond(hn Handler, sess mux.Session, ch mux.Channel, ctx context.Context) {
 	framer := &FrameCodec{Codec: s.Codec}
 	dec := framer.Decoder(ch)
 

--- a/talk/dial.go
+++ b/talk/dial.go
@@ -8,7 +8,7 @@ import (
 )
 
 // A Dialer connects to address and establishes a mux.Session
-type Dialer func(addr string) (*mux.Session, error)
+type Dialer func(addr string) (mux.Session, error)
 
 // Dialers is map of transport strings to Dialers
 // and includes all builtin transports
@@ -19,7 +19,7 @@ func init() {
 		"tcp":  mux.DialTCP,
 		"unix": mux.DialUnix,
 		"ws":   mux.DialWS,
-		"stdio": func(_ string) (*mux.Session, error) {
+		"stdio": func(_ string) (mux.Session, error) {
 			return mux.DialStdio()
 		},
 	}

--- a/talk/peer.go
+++ b/talk/peer.go
@@ -8,14 +8,14 @@ import (
 
 // Peer is a mux session, RPC client and responder, all in one.
 type Peer struct {
-	*mux.Session
+	mux.Session
 	*rpc.Client
 	*rpc.RespondMux
 	codec.Codec
 }
 
 // NewPeer returns a Peer based on a session and codec.
-func NewPeer(session *mux.Session, codec codec.Codec) *Peer {
+func NewPeer(session mux.Session, codec codec.Codec) *Peer {
 	return &Peer{
 		Session:    session,
 		Codec:      codec,


### PR DESCRIPTION
In preparation for changes like a QUIC implementation for #2, turn
`Session` and `Channel` into interfaces. This way we can provide a more direct
mapping from QUIC to sessions & channels rather than wrapping a single data
stream with the existing session implementation.
