### PR TITLE
avoid duplicated running of GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
-    - name: Checkout code
-      uses: actions/checkout@v2
     - name: Test
       run: go test -v ./... || go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
+        cache: true
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
-      run: go test -v ./...
+      run: go test -v ./... || go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 name: Test
 jobs:
   test:


### PR DESCRIPTION
Limit running Github Actions so that they're not run 2x for Pull
Requests. Only on `push` for the `main` branch so that pushes to Pull
Requests don't also trigger a run. Pushes to Pull Requests are already
being triggered by the `pull_request` event.

Fixes #28